### PR TITLE
Remove of un-needed line

### DIFF
--- a/mysql-replica/slave/Dockerfile
+++ b/mysql-replica/slave/Dockerfile
@@ -65,7 +65,6 @@ RUN { \
 RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/mysql.conf.d/mysqld.cnf \
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
-RUN sed -i '/\[mysqld\]/a server-id=1\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf
 RUN RAND="$(date +%s | rev | cut -c 1-2)$(echo ${RANDOM})" && sed -i '/\[mysqld\]/a server-id='$RAND'\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf
 
 VOLUME /var/lib/mysql


### PR DESCRIPTION
removal of following line, as it contradicts the line that comes after, which offers a random server-id for the slave.

`RUN sed -i '/\[mysqld\]/a server-id=1\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf`